### PR TITLE
Nginx :directive ```proxy_kernel_network_stack```

### DIFF
--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -38,7 +38,23 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
 
     type = (pc->type ? pc->type : SOCK_STREAM);
 
+#if (NGX_HAVE_FSTACK)
+    /* 
+     We need to explicitly call the needed socket() function
+         to create socket!
+    */
+    static int (*real_socket)(int, int, int);
+    if (pc->belong_to_host) {
+        if (!real_socket) {
+            real_socket = dlsym(RTLD_NEXT, "socket");
+        }
+        s = real_socket(pc->sockaddr->sa_family, type, 0);
+    } else {
+        s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+    }
+#else
     s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+#endif
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
                    (type == SOCK_STREAM) ? "stream" : "dgram", s);

--- a/app/nginx-1.11.10/src/event/ngx_event_connect.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.h
@@ -66,6 +66,10 @@ struct ngx_peer_connection_s {
                                      /* ngx_connection_log_error_e */
     unsigned                         log_error:2;
 
+#if (NGX_HAVE_FSTACK)
+    unsigned                         belong_to_host:1;
+#endif
+
     NGX_COMPAT_BEGIN(2)
     NGX_COMPAT_END
 };

--- a/app/nginx-1.11.10/src/http/ngx_http_core_module.c
+++ b/app/nginx-1.11.10/src/http/ngx_http_core_module.c
@@ -3455,7 +3455,9 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
     cscf->ignore_invalid_headers = NGX_CONF_UNSET;
     cscf->merge_slashes = NGX_CONF_UNSET;
     cscf->underscores_in_headers = NGX_CONF_UNSET;
+#if (NGX_HAVE_FSTACK)
     cscf->kernel_network_stack = NGX_CONF_UNSET;
+#endif
 
     return cscf;
 }

--- a/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
+++ b/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
@@ -67,10 +67,10 @@ static ngx_command_t  ngx_mail_core_commands[] = {
 #if (NGX_HAVE_FSTACK)
 
     { ngx_string("kernel_network_stack"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
-      NGX_HTTP_SRV_CONF_OFFSET,
-      offsetof(ngx_http_core_srv_conf_t, kernel_network_stack),
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_core_srv_conf_t, kernel_network_stack),
       NULL },
 
 #endif

--- a/doc/F-Stack_Nginx_APP_Guide.md
+++ b/doc/F-Stack_Nginx_APP_Guide.md
@@ -42,21 +42,37 @@ first one to start |                    |     |                   |    |        
 
 - a major addition to the worker process is fstack-handling：ff_init();ff_run(worker_process_cycle); worker_process_cycle(handle channel/host/fstack event).
 
-- a new directive `kernel_network_stack` :
+## What's Different?
+### New directives:
+All the directives below are available only when ```NGX_HAVE_FSTACK``` is defined.
 ```
     Syntax: kernel_network_stack on | off;
     Default: kernel_network_stack off;
     Context: http, server
-    This directive is available only when ```NGX_HAVE_FSTACK``` is defined.
+
     Determines whether server should run on kernel network stack or fstack.
 ```
 
-Note that:
+```
+    Syntax: proxy_kernel_network_stack on | off;
+    Default: kernel_network_stack off;
+    Context: http, stream, mail, server
 
-- the `reload` is not graceful, service will still be unavailable during the process of reloading.
+    Determines whether proxy should go through kernel network stack or fstack.
+```
 
-- necessary modifies in nginx.conf:
+```
+    Syntax: schedule_timeout time;
+    Default: schedule_timeout 30m;
+    Context: http, server
 
+    Sets a time interval for polling kernel_network_stack. The default value is 30 msec.
+```
+
+### Command-line `reload`
+the `reload` is not graceful, service will still be unavailable during the process of reloading.
+
+### Necessary modifies in nginx.conf:
 ```
     user  root; # root account is necessary.
     fstack_conf f-stack.conf;  # path of f-stack configuration file, default: $NGX_PREFIX/conf/f-stack.conf.


### PR DESCRIPTION
1. Add a new directive proxy_kernel_network_stack :
    Syntax: 	proxy_kernel_network_stack on | off;
    Default: 	proxy_kernel_network_stack off;
   Context: 	http, stream, mail, server
  This directive is available only when NGX_HAVE_FF_STACK is defined.
  Determines whether proxy should go throught kernel network stack or fstack.
2.Update F-Stack_Nginx_APP_Guide.md